### PR TITLE
AssemblyScript support plus some new commands and minor fixes

### DIFF
--- a/assemblyscript/.gitignore
+++ b/assemblyscript/.gitignore
@@ -1,0 +1,3 @@
+build
+node_modules
+

--- a/assemblyscript/justfile
+++ b/assemblyscript/justfile
@@ -1,0 +1,12 @@
+help:
+    just -l
+
+build:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    npm install --silent
+    mkdir -p out
+    find src/*.ts | xargs -n1 -I '{}' -- npx asbuild {}
+
+list-wasm:
+    find build/release/*.wasm

--- a/assemblyscript/package-lock.json
+++ b/assemblyscript/package-lock.json
@@ -1,0 +1,103 @@
+{
+  "name": "assemblyscript",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "assemblyscript",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "as-wasi": "^0.5.1",
+        "assemblyscript": "^0.26.7"
+      }
+    },
+    "node_modules/@assemblyscript/wasi-shim": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@assemblyscript/wasi-shim/-/wasi-shim-0.1.0.tgz",
+      "integrity": "sha512-fSLH7MdJHf2uDW5llA5VCF/CG62Jp2WkYGui9/3vIWs3jDhViGeQF7nMYLUjpigluM5fnq61I6obtCETy39FZw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/assemblyscript"
+      }
+    },
+    "node_modules/as-wasi": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/as-wasi/-/as-wasi-0.5.1.tgz",
+      "integrity": "sha512-urJEqJgxkz7YQv107wGp5qDorg1eCUf1tKruL1XYLgwI3+TLULMhWkoJ1Mwtz4zMtC/zc5LsrmCCmcVM4VNteg==",
+      "dependencies": {
+        "@assemblyscript/wasi-shim": "^0.1"
+      }
+    },
+    "node_modules/assemblyscript": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.26.7.tgz",
+      "integrity": "sha512-+zjr7RZotrNleOc2raZQJVIoMQ906LmZP9Q9C9IUft3o5QIzerQdKboHIwyO4HZUZor3dG0e9vIFK7w1l0PCsw==",
+      "dependencies": {
+        "binaryen": "111.0.0-nightly.20230111",
+        "long": "^5.2.0"
+      },
+      "bin": {
+        "asc": "bin/asc.js",
+        "asinit": "bin/asinit.js"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/assemblyscript"
+      }
+    },
+    "node_modules/binaryen": {
+      "version": "111.0.0-nightly.20230111",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-111.0.0-nightly.20230111.tgz",
+      "integrity": "sha512-CUEED/yMHoGeGnOZhQJW5+Luf5z/F58PHK5lw2feh5fbbqauodgnxyYkc2oxSjYwHHRCmFmaYyeQH4zlhRbebg==",
+      "bin": {
+        "wasm-opt": "bin/wasm-opt",
+        "wasm2js": "bin/wasm2js"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
+      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
+    }
+  },
+  "dependencies": {
+    "@assemblyscript/wasi-shim": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@assemblyscript/wasi-shim/-/wasi-shim-0.1.0.tgz",
+      "integrity": "sha512-fSLH7MdJHf2uDW5llA5VCF/CG62Jp2WkYGui9/3vIWs3jDhViGeQF7nMYLUjpigluM5fnq61I6obtCETy39FZw=="
+    },
+    "as-wasi": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/as-wasi/-/as-wasi-0.5.1.tgz",
+      "integrity": "sha512-urJEqJgxkz7YQv107wGp5qDorg1eCUf1tKruL1XYLgwI3+TLULMhWkoJ1Mwtz4zMtC/zc5LsrmCCmcVM4VNteg==",
+      "requires": {
+        "@assemblyscript/wasi-shim": "^0.1"
+      }
+    },
+    "assemblyscript": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.26.7.tgz",
+      "integrity": "sha512-+zjr7RZotrNleOc2raZQJVIoMQ906LmZP9Q9C9IUft3o5QIzerQdKboHIwyO4HZUZor3dG0e9vIFK7w1l0PCsw==",
+      "requires": {
+        "binaryen": "111.0.0-nightly.20230111",
+        "long": "^5.2.0"
+      }
+    },
+    "binaryen": {
+      "version": "111.0.0-nightly.20230111",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-111.0.0-nightly.20230111.tgz",
+      "integrity": "sha512-CUEED/yMHoGeGnOZhQJW5+Luf5z/F58PHK5lw2feh5fbbqauodgnxyYkc2oxSjYwHHRCmFmaYyeQH4zlhRbebg=="
+    },
+    "long": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
+      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
+    }
+  }
+}

--- a/assemblyscript/package.json
+++ b/assemblyscript/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "assemblyscript",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "as-wasi": "^0.5.1",
+    "assemblyscript": "^0.26.7"
+  }
+}

--- a/assemblyscript/src/as-fib.ts
+++ b/assemblyscript/src/as-fib.ts
@@ -1,0 +1,13 @@
+export function fib(n: i32): i32 {
+  var a = 0,
+    b = 1;
+  if (n > 0) {
+    while (--n) {
+      let t = a + b;
+      a = b;
+      b = t;
+    }
+    return b;
+  }
+  return a;
+}

--- a/assemblyscript/src/as-hello.ts
+++ b/assemblyscript/src/as-hello.ts
@@ -1,0 +1,3 @@
+import "wasi";
+
+console.log("Hello, Serval!");

--- a/justfile
+++ b/justfile
@@ -37,3 +37,6 @@ build PROJECT='':
         cp target/wasm32-wasi/release/*.wasm ../build/
     fi
     cd ..
+
+clean:
+    rm build/*.wasm

--- a/justfile
+++ b/justfile
@@ -32,6 +32,7 @@ build PROJECT='':
     else
         # If there is no justfile, we simply `cargo build` and grab the output.
         cargo build --release --target wasm32-wasi --quiet
+        chmod -x target/wasm32-wasi/release/*.wasm # https://serval.slack.com/archives/C04BKH1J31S/p1674672880593649
         find target/wasm32-wasi/release/*.wasm | xargs -n1 -I'{}' wasm-opt '{}' -Oz -o '{}'
         cp target/wasm32-wasi/release/*.wasm ../build/
     fi

--- a/justfile
+++ b/justfile
@@ -38,5 +38,16 @@ build PROJECT='':
     fi
     cd ..
 
+build-and-run PROJECT BINARY='':
+    #!/bin/bash
+    just build {{PROJECT}}
+    if [ "{{BINARY}}" == "" ]; then
+        BINARY=build/{{PROJECT}}.wasm
+    else
+        BINARY={{BINARY}}
+    fi
+    pushd ../serval-mesh
+    cargo run --bin serval -- run ../wasm-samples/${BINARY}
+
 clean:
     rm build/*.wasm

--- a/sdk-test/Cargo.lock
+++ b/sdk-test/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
-name = "call-a-host-function"
+name = "sdk-test"
 version = "0.1.0"
 dependencies = [
  "serval",

--- a/sdk-test/Cargo.toml
+++ b/sdk-test/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "call-a-host-function"
+name = "sdk-test"
 version = "0.1.0"
 edition = "2021"
 


### PR DESCRIPTION
This adds an AssemblyScript demo, which seemed like a good choice for an "anything but Rust" implementation language for demos. For those unfamiliar with [AssemblyScript](https://www.assemblyscript.org), it's a small language with a syntax that's similar to TypeScript, and it's pretty easy to get started with. Highly recommended.

I also added a few new commands to make life easier:
- `just clean` nukes the contents of the build directory
- `just build-and-run <project>` compiles the given project and then runs it in serval, assuming that wasm-samples and serval-mesh are checked out as sibling projects.